### PR TITLE
Add action to propagate new tags to meta-package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ jobs:
         uses: tibdex/github-app-token@v1
         id: generate-token
         with:
-          app_id: ${{ secrets.BOT_APP_ID }}
-          private_key: ${{ secrets.BOT_PRIVATE_KEY }}
+          app_id: ${{ secrets.WORDPRESS_PACKAGER_BOT_APP_ID }}
+          private_key: ${{ secrets.WORDPRESS_PACKAGER_BOT_PRIVATE_KEY }}
 
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  meta:
+    name: Meta-package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.BOT_APP_ID }}
+          private_key: ${{ secrets.BOT_PRIVATE_KEY }}
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          repository: ${{ secrets.META_PACKAGE }}
+          token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
Via GitHub Actions automation.
As soon as a new tag is pushed, a new release is made available on `roots/wordpress`.

Require setting up following secrets
* `META_PACKAGE`: `roots/wordpress`
* `BOT_APP_ID`: same value as`roots/wordpress-packager`
* `BOT_PRIVATE_KEY`: same value as`roots/wordpress-packager`

Plus adding the app to `roots/wordpress`.