### PR TITLE
Drop installer requirement for nightlies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,7 @@
         "url": "https://wordpress.org/nightly-builds/wordpress-latest.zip"
     },
     "require": {
-        "php": ">= 5.6.20",
-        "roots/wordpress-core-installer": "^1.0"
+        "php": ">= 5.6.20"
     },
     "provide": {
         "wordpress/core-implementation": "dev-nightly"


### PR DESCRIPTION
Follow up of https://github.com/roots/wordpress-packager/pull/507