### PR TITLE
Reflect WordPress new minimum PHP version requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
         "url": "https://wordpress.org/nightly-builds/wordpress-latest.zip"
     },
     "require": {
-        "php": ">= 7.0.0"
+        "php": ">= 7.2.24"
     },
     "provide": {
         "wordpress/core-implementation": "dev-nightly"


### PR DESCRIPTION
Same as https://github.com/roots/wordpress-full/pull/5